### PR TITLE
Using implementation instead of compile to get rid of warning

### DIFF
--- a/src/android/plugin.gradle
+++ b/src/android/plugin.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.ExCiteS:apache-commons-codec-shaded:1.11'
+    implementation 'com.github.ExCiteS:apache-commons-codec-shaded:1.11'
 }


### PR DESCRIPTION
As officially specified in https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations