### PR TITLE
Allow any non-breaking cordova-plugin-add-swift-support version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cordova-aes256"
   ],
   "dependencies": {
-    "cordova-plugin-add-swift-support": "2.0.1"
+    "cordova-plugin-add-swift-support": "^2.0.1"
   },
   "author": "Ideas2it",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cordova-aes256"
   ],
   "dependencies": {
-    "cordova-plugin-add-swift-support": "^2.0.1"
+    "cordova-plugin-add-swift-support": "^2.0.2"
   },
   "author": "Ideas2it",
   "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,6 +27,6 @@
         <source-file src="src/ios/AES256.swift" />
         <source-file src="src/ios/AES256CBC.swift" />
         <source-file src="src/ios/PBKDF2.swift" />
-        <dependency id="cordova-plugin-add-swift-support" version="2.0.1"/>
+        <dependency id="cordova-plugin-add-swift-support" version="^2.0.2"/>
     </platform>
 </plugin>


### PR DESCRIPTION
Configured dependency according to more flexible semver