### PR TITLE
Fix unwrap during invalid base64 strings;

### DIFF
--- a/src/ios/AES256CBC.swift
+++ b/src/ios/AES256CBC.swift
@@ -318,7 +318,9 @@ final public class AES256CBC {
     fileprivate class func aesDecrypt(_ str: String, key: String, iv: String) throws -> String {
         let keyData = key.data(using: String.Encoding.utf8)!
         let ivData = iv.data(using: String.Encoding.utf8)!
-        let data = Data(base64Encoded: str)!
+        guard let data = Data(base64Encoded: str) else {
+            throw NSError(domain: "Invalid base64 data", code: 0, userInfo: nil)
+        }
         let dec = try Data(bytes: AESCipher(key: keyData.bytes,
                                             iv: ivData.bytes).decrypt(bytes: data.bytes))
         guard let decryptStr = String(data: dec, encoding: String.Encoding.utf8) else {


### PR DESCRIPTION
During some accidental tests using ionic v5, I've passed invalid base64 strings to decrypt functions causing the application to crash. Add a guard let statement to avoid that.